### PR TITLE
Add custom widgets: AppButton, AppCard, AppTextField, ErrorView, and …

### DIFF
--- a/lib/core/widgets/app_button.dart
+++ b/lib/core/widgets/app_button.dart
@@ -1,0 +1,172 @@
+import 'package:employee_attendance/core/constants/app_colors.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import '../constants/app_fonts.dart';
+
+enum AppButtonType { primary, secondary, outline }
+enum AppButtonSize { small, medium, large }
+
+class AppButton extends StatelessWidget {
+  final String text;
+  final VoidCallback? onPressed;
+  final AppButtonType type;
+  final AppButtonSize size;
+  final IconData? icon;
+  final bool isLoading;
+  final bool fullWidth;
+
+  const AppButton({
+    super.key,
+    required this.text,
+    this.onPressed,
+    this.type = AppButtonType.primary,
+    this.size = AppButtonSize.medium,
+    this.icon,
+    this.isLoading = false,
+    this.fullWidth = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: fullWidth ? double.infinity : null,
+      height: _getHeight(),
+      child: ElevatedButton(
+        onPressed: isLoading ? null : onPressed,
+        style: _getButtonStyle(),
+        child: _buildChild(),
+      ),
+    );
+  }
+
+  Widget _buildChild() {
+    if (isLoading) {
+      return SizedBox(
+        height: 20.h,
+        width: 20.w,
+        child: CircularProgressIndicator(
+          strokeWidth: 2,
+          valueColor: AlwaysStoppedAnimation<Color>(_getTextColor()),
+        ),
+      );
+    }
+
+    if (icon != null) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: _getIconSize()),
+          SizedBox(width: 8.w),
+          Text(text, style: _getTextStyle()),
+        ],
+      );
+    }
+
+    return Text(text, style: _getTextStyle());
+  }
+
+  double _getHeight() {
+    switch (size) {
+      case AppButtonSize.small:
+        return 32.h;
+      case AppButtonSize.medium:
+        return 40.h;
+      case AppButtonSize.large:
+        return 48.h;
+    }
+  }
+
+  double _getIconSize() {
+    switch (size) {
+      case AppButtonSize.small:
+        return 16.sp;
+      case AppButtonSize.medium:
+        return 20.sp;
+      case AppButtonSize.large:
+        return 24.sp;
+    }
+  }
+
+  TextStyle _getTextStyle() {
+    return AppFonts.labelLarge.copyWith(
+      color: _getTextColor(),
+      fontSize: _getTextSize(),
+    );
+  }
+
+  double _getTextSize() {
+    switch (size) {
+      case AppButtonSize.small:
+        return 12.sp;
+      case AppButtonSize.medium:
+        return 14.sp;
+      case AppButtonSize.large:
+        return 16.sp;
+    }
+  }
+
+  Color _getTextColor() {
+    switch (type) {
+      case AppButtonType.primary:
+        return AppColors.textPrimary;
+      case AppButtonType.secondary:
+        return AppColors.primary;
+      case AppButtonType.outline:
+        return AppColors.primary;
+    }
+  }
+
+  ButtonStyle _getButtonStyle() {
+    return ElevatedButton.styleFrom(
+      backgroundColor: _getBackgroundColor(),
+      foregroundColor: _getTextColor(),
+      elevation: _getElevation(),
+      padding: _getPadding(),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8.r),
+        side: _getBorderSide(),
+      ),
+    );
+  }
+
+  Color _getBackgroundColor() {
+    switch (type) {
+      case AppButtonType.primary:
+        return AppColors.primary;
+      case AppButtonType.secondary:
+        return AppColors.primary.withOpacity(0.1);
+      case AppButtonType.outline:
+        return Colors.transparent;
+    }
+  }
+
+  double _getElevation() {
+    switch (type) {
+      case AppButtonType.primary:
+        return 2;
+      case AppButtonType.secondary:
+      case AppButtonType.outline:
+        return 0;
+    }
+  }
+
+  EdgeInsetsGeometry _getPadding() {
+    switch (size) {
+      case AppButtonSize.small:
+        return EdgeInsets.symmetric(horizontal: 12.w);
+      case AppButtonSize.medium:
+        return EdgeInsets.symmetric(horizontal: 16.w);
+      case AppButtonSize.large:
+        return EdgeInsets.symmetric(horizontal: 24.w);
+    }
+  }
+
+  BorderSide _getBorderSide() {
+    switch (type) {
+      case AppButtonType.outline:
+        return const BorderSide(color: AppColors.primary);
+      default:
+        return BorderSide.none;
+    }
+  }
+}

--- a/lib/core/widgets/app_card.dart
+++ b/lib/core/widgets/app_card.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import '../constants/app_colors.dart';
+import '../constants/app_theme.dart';
+
+class AppCard extends StatelessWidget {
+  final Widget child;
+  final EdgeInsetsGeometry? padding;
+  final Color? backgroundColor;
+  final double? borderRadius;
+  final Border? border;
+  final VoidCallback? onTap;
+
+  const AppCard({
+    super.key,
+    required this.child,
+    this.padding,
+    this.backgroundColor,
+    this.borderRadius,
+    this.border,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final card = Container(
+      padding: padding ?? EdgeInsets.all(AppSpacing.md),
+      decoration: BoxDecoration(
+        color: backgroundColor ?? AppColors.cardBackground,
+        borderRadius: BorderRadius.circular(borderRadius ?? 12.r),
+        border: border,
+      ),
+      child: child,
+    );
+
+    if (onTap != null) {
+      return InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(borderRadius ?? 12.r),
+        child: card,
+      );
+    }
+
+    return card;
+  }
+}

--- a/lib/core/widgets/app_text_field.dart
+++ b/lib/core/widgets/app_text_field.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+import '../constants/app_colors.dart';
+import '../constants/app_fonts.dart';
+
+class AppTextField extends StatelessWidget {
+  final String? label;
+  final String? hint;
+  final TextEditingController? controller;
+  final String? Function(String?)? validator;
+  final TextInputType? keyboardType;
+  final List<TextInputFormatter>? inputFormatters;
+  final bool obscureText;
+  final Widget? prefixIcon;
+  final Widget? suffixIcon;
+  final int? maxLines;
+  final int? minLines;
+  final bool readOnly;
+  final VoidCallback? onTap;
+  final void Function(String)? onChanged;
+  final FocusNode? focusNode;
+
+  const AppTextField({
+    super.key,
+    this.label,
+    this.hint,
+    this.controller,
+    this.validator,
+    this.keyboardType,
+    this.inputFormatters,
+    this.obscureText = false,
+    this.prefixIcon,
+    this.suffixIcon,
+    this.maxLines = 1,
+    this.minLines,
+    this.readOnly = false,
+    this.onTap,
+    this.onChanged,
+    this.focusNode,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (label != null) ...[
+          Text(
+            label!,
+            style: AppFonts.bodyMedium.copyWith(
+              color: AppColors.textSecondary,
+            ),
+          ),
+          SizedBox(height: 8.h),
+        ],
+        TextFormField(
+          controller: controller,
+          validator: validator,
+          keyboardType: keyboardType,
+          inputFormatters: inputFormatters,
+          obscureText: obscureText,
+          maxLines: maxLines,
+          minLines: minLines,
+          readOnly: readOnly,
+          onTap: onTap,
+          onChanged: onChanged,
+          focusNode: focusNode,
+          style: AppFonts.bodyLarge,
+          decoration: InputDecoration(
+            hintText: hint,
+            hintStyle: AppFonts.bodyLarge.copyWith(
+              color: AppColors.textSecondary,
+            ),
+            prefixIcon: prefixIcon,
+            suffixIcon: suffixIcon,
+            filled: true,
+            fillColor: AppColors.surface,
+            contentPadding: EdgeInsets.symmetric(
+              horizontal: 16.w,
+              vertical: 12.h,
+            ),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8.r),
+              borderSide: BorderSide.none,
+            ),
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8.r),
+              borderSide: BorderSide.none,
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8.r),
+              borderSide: const BorderSide(
+                color: AppColors.primary,
+                width: 2,
+              ),
+            ),
+            errorBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8.r),
+              borderSide: const BorderSide(
+                color: AppColors.error,
+                width: 2,
+              ),
+            ),
+            focusedErrorBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8.r),
+              borderSide: const BorderSide(
+                color: AppColors.error,
+                width: 2,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/core/widgets/error_view.dart
+++ b/lib/core/widgets/error_view.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:iconsax/iconsax.dart';
+import '../constants/app_colors.dart';
+import '../constants/app_fonts.dart';
+
+class ErrorView extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+  final IconData icon;
+  final String retryText;
+
+  const ErrorView({
+    super.key,
+    required this.message,
+    required this.onRetry,
+    this.icon = Iconsax.warning_2,
+    this.retryText = 'Try Again',
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              icon,
+              size: 64,
+              color: AppColors.error,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              message,
+              style: AppFonts.bodyLarge.copyWith(
+                color: AppColors.error,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton.icon(
+              onPressed: onRetry,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.primary,
+                foregroundColor: AppColors.textPrimary,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 24,
+                  vertical: 12,
+                ),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+              icon: const Icon(Iconsax.refresh),
+              label: Text(
+                retryText,
+                style: AppFonts.bodyLarge,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/loading_view.dart
+++ b/lib/core/widgets/loading_view.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import '../constants/app_colors.dart';
+
+class LoadingView extends StatelessWidget {
+  final String? message;
+
+  const LoadingView({
+    super.key,
+    this.message,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const CircularProgressIndicator(
+            valueColor: AlwaysStoppedAnimation<Color>(AppColors.primary),
+          ),
+          if (message != null) ...[
+            const SizedBox(height: 16),
+            Text(
+              message!,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: AppColors.textPrimary,
+                  ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
…LoadingView

This commit introduces several reusable widgets to enhance the UI components of the application. The new widgets include:

- **AppButton**: A customizable button with different styles and sizes.
- **AppCard**: A card widget that can contain child widgets with optional padding, background color, and border.
- **AppTextField**: A versatile text input field with support for labels, hints, and various input configurations.
- **ErrorView**: A user-friendly error display with an icon and retry functionality.
- **LoadingView**: A loading indicator with an optional message.

These components aim to improve code reusability and maintainability across the application.