### PR TITLE
Fix screen size issue in release mode

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'core/di/injection_container.dart';
 import 'my_app.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // To fix texts being hidden bug in flutter_screenutil in release mode.
+  await ScreenUtil.ensureScreenSize();
 
   // Set preferred orientations
   await SystemChrome.setPreferredOrientations([


### PR DESCRIPTION
Ensure the screen size is properly initialized by calling ScreenUtil.ensureScreenSize() in the main function. This addresses the bug where texts were hidden when using flutter_screenutil in release mode.