### PR TITLE
Update leave status handling and improve snackbar appearance

### DIFF
--- a/lib/features/leave/presentation/screens/leave_list_screen.dart
+++ b/lib/features/leave/presentation/screens/leave_list_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:iconsax/iconsax.dart';
 import '../../../../core/constants/app_colors.dart';
 import '../../../../core/constants/app_fonts.dart';
@@ -70,7 +71,10 @@ class _LeaveListScreenState extends State<LeaveListScreen>
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(message),
-        backgroundColor: backgroundColor,
+        backgroundColor: backgroundColor ?? AppColors.primary,
+        behavior: SnackBarBehavior.floating,
+        margin: EdgeInsets.all(16.w),
+        duration: const Duration(seconds: 3),
       ),
     );
   }
@@ -160,9 +164,9 @@ class _LeaveListScreenState extends State<LeaveListScreen>
   void _updateLeaveStatus(String leaveId, LeaveStatus status) {
     try {
       context.read<LeaveCubit>().updateLeaveStatus(
-            leaveId: leaveId,
-            status: status,
-          );
+        leaveId: leaveId,
+        status: status,
+      );
     } catch (e) {
       _showSnackBar(
         'Failed to update leave status: $e',

--- a/lib/features/leave/presentation/widgets/leave_card.dart
+++ b/lib/features/leave/presentation/widgets/leave_card.dart
@@ -173,7 +173,31 @@ class LeaveCard extends StatelessWidget {
 
   void _handleStatusUpdate(BuildContext context, LeaveStatus status) {
     try {
-      onUpdateStatus?.call(leave.id, status);
+      showDialog(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: Text(
+            'Confirm Action',
+            style: AppFonts.bodyLarge,
+          ),
+          content: Text(
+              'Are you sure you want to ${status == LeaveStatus.approved ? 'approve' : 'reject'} this leave request?',
+              style: AppFonts.bodyMedium),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: Text('Cancel', style: AppFonts.bodyMedium),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.pop(context);
+                onUpdateStatus?.call(leave.id, status);
+              },
+              child: Text('Confirm', style: AppFonts.bodyMedium),
+            ),
+          ],
+        ),
+      );
     } catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(


### PR DESCRIPTION
Refactor the `LeaveCubit` to fetch and update the leave list after a status change. Improve the snackbar appearance in `LeaveListScreen` by setting default background color, behavior, margin, and duration. Add a confirmation dialog in `LeaveCard` before updating the leave status.