### PR TITLE
Prevent unnecessary state updates and fix leave duration calculation

### DIFF
--- a/lib/features/attendance/presentation/screens/home_screen.dart
+++ b/lib/features/attendance/presentation/screens/home_screen.dart
@@ -40,10 +40,12 @@ class _HomeScreenState extends State<HomeScreen>
   }
 
   onTapChange(int index) {
-    setState(() {
-      _selectedIndex = index;
-      _tabController!.index = _selectedIndex;
-    });
+    if (index != _selectedIndex && index != 2) {
+      setState(() {
+        _selectedIndex = index;
+        _tabController!.index = _selectedIndex;
+      });
+    }
   }
 
   void _handleAttendanceAction() async {
@@ -180,7 +182,7 @@ class _HomeScreenState extends State<HomeScreen>
                 label: 'Calendar',
               ),
               BottomNavigationBarItem(
-                icon: Icon(null, size: 5.sp),
+                icon: Icon(null, size: 0.sp),
                 label: '',
               ),
               BottomNavigationBarItem(

--- a/lib/features/leave/domain/entities/leave.dart
+++ b/lib/features/leave/domain/entities/leave.dart
@@ -50,7 +50,7 @@ class Leave extends Equatable {
   });
 
   int get duration {
-    return endDate.difference(startDate).inDays + 1;
+    return endDate.difference(startDate).inDays;
   }
 
   // Calculate the number of working days between two dates
@@ -71,7 +71,8 @@ class Leave extends Equatable {
     return workingDays;
   }
 
-  int get workingDays => calculateWorkingDays(startDate, endDate);
+  int get workingDays => calculateWorkingDays(
+      startDate, endDate.subtract(const Duration(days: 1)));
 
   bool get isPending => status == LeaveStatus.pending;
   bool get isApproved => status == LeaveStatus.approved;


### PR DESCRIPTION
- Updated `onTapChange` method to prevent state updates when the selected index is the same or the middle index (2).
- Adjusted the `duration` getter in the `Leave` class to correctly calculate the number of days between `startDate` and `endDate`.
- Set the icon size to 0.sp for the middle `BottomNavigationBarItem` to effectively hide it.